### PR TITLE
Fix workflow: Pull before push to avoid rejection

### DIFF
--- a/.github/workflows/regwatch.yml
+++ b/.github/workflows/regwatch.yml
@@ -50,6 +50,14 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          
+          # Configure token for authentication
+          git remote set-url origin https://${GITHUB_TOKEN}@github.com/mgillr/nextalent-regwatch.git
+          
+          # Pull latest changes with rebase strategy
+          git pull --rebase origin master
+          
+          # Add files
           git add out/
           if [ -f "regwatch.json" ]; then
             git add regwatch.json
@@ -63,9 +71,11 @@ jobs:
           if [ -f "index.html" ]; then
             git add index.html
           fi
+          
+          # Commit and push if there are changes
           if ! git diff --quiet || ! git diff --staged --quiet; then
             git commit -m "Update RegWatch data [skip ci]"
-            git push https://${GITHUB_TOKEN}@github.com/mgillr/nextalent-regwatch.git HEAD:master
+            git push origin HEAD:master
           fi
       
       - name: Setup Pages


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow that was failing with the error:

```
error: failed to push some refs to 'https://github.com/mgillr/nextalent-regwatch.git'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref.
```

Changes:
1. Added proper git remote configuration with authentication token
2. Added a `git pull --rebase` step before pushing to ensure we have the latest changes
3. Improved code organization with comments for better readability
4. Simplified the push command since we've already set the remote URL

This should resolve the workflow failures and ensure that the RegWatch data is properly updated and deployed to GitHub Pages.