### PR TITLE
Fix workflow: Stash changes before pull to avoid conflicts

### DIFF
--- a/.github/workflows/regwatch.yml
+++ b/.github/workflows/regwatch.yml
@@ -54,8 +54,14 @@ jobs:
           # Configure token for authentication
           git remote set-url origin https://${GITHUB_TOKEN}@github.com/mgillr/nextalent-regwatch.git
           
-          # Pull latest changes with rebase strategy
-          git pull --rebase origin master
+          # First, stash any changes to avoid conflicts
+          git stash -u || true
+          
+          # Pull latest changes
+          git pull origin master
+          
+          # Pop the stashed changes
+          git stash pop || true
           
           # Add files
           git add out/


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow that was failing with the error:

```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
```

Changes:
1. Added `git stash -u || true` to save any unstaged changes before pulling
2. Changed from `git pull --rebase` to `git pull` to simplify the process
3. Added `git stash pop || true` to restore any stashed changes after pulling
4. Added `|| true` to prevent the workflow from failing if there's nothing to stash/pop

This should resolve the workflow failures and ensure that the RegWatch data is properly updated and deployed to GitHub Pages.